### PR TITLE
fix/store : 새로고침 시 데이터 휘발되는 에러 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-router-bootstrap": "^0.26.2",
     "react-router-dom": "^6.14.1",
     "react-scripts": "5.0.1",
+    "redux-persist": "^6.0.0",
     "styled-components": "^6.0.7",
     "web-vitals": "^2.1.4",
     "yup": "^1.3.0"

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,15 @@
 import { router } from './routes/router';
-import FontSizingProvider from './context/FontSizingProvider';
-import LayoutContainer from './components/layout/LayoutContainer';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import store from './store';
+import { PersistGate } from 'redux-persist/integration/react';
 import { CookiesProvider } from 'react-cookie';
 import { GoogleOAuthProvider } from '@react-oauth/google';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import FontSizingProvider from './context/FontSizingProvider';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import LayoutContainer from './components/layout/LayoutContainer';
 import { GlobalFont } from './styles/GlobalFont';
+import { store, persistor } from './store';
 
 const client = new QueryClient();
 
@@ -19,12 +20,14 @@ function App() {
         <QueryClientProvider client={client}>
           <CookiesProvider>
             <Provider store={store}>
-              <GoogleOAuthProvider
-                clientId={process.env.REACT_APP_GOOGLE_AUTH_CLIENT_KEY}
-              >
-                <GlobalFont />
-                <RouterProvider router={router} />
-              </GoogleOAuthProvider>
+              <PersistGate loading={null} persistor={persistor}>
+                <GoogleOAuthProvider
+                  clientId={process.env.REACT_APP_GOOGLE_AUTH_CLIENT_KEY}
+                >
+                  <GlobalFont />
+                  <RouterProvider router={router} />
+                </GoogleOAuthProvider>
+              </PersistGate>
             </Provider>
             {/* <ReactQueryDevtools initialIsOpen={false} /> */}
           </CookiesProvider>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,12 +1,27 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 import { userSlice } from './Slices/auth';
 import { bookmarkSlice } from './Slices/bookmark';
 
-const store = configureStore({
-  reducer: {
-    user: userSlice.reducer,
-    bookmark: bookmarkSlice.reducer,
-  },
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['user', 'bookmark'],
+  log: true,
+};
+
+const rootReducer = combineReducers({
+  user: userSlice.reducer,
+  bookmark: bookmarkSlice.reducer,
 });
 
-export default store;
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+const store = configureStore({
+  reducer: persistedReducer,
+});
+
+const persistor = persistStore(store);
+
+export { store, persistor };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,6 +20,10 @@ const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 const store = configureStore({
   reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
 });
 
 const persistor = persistStore(store);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8565,6 +8565,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-thunk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz"


### PR DESCRIPTION
### 구현 기능
- redux-persist 설치
- 새로고침 시 store에 있는 데이터 (auth, bookmarkedQuestion) 초기화 되는 문제 redux-persist로 해결
- redux action 에 직렬화 할 수 없는 값이 저장되어 발생하는 serializable 문제 발견 -> 직렬화 가능한 값을 체크하는 미들웨어 사용하지 않도록 하여 해결 ()