### PR TITLE
fix/mypage : 유저 정보 업데이트 버그 수정

### DIFF
--- a/src/constant/queryKeyFactory.js
+++ b/src/constant/queryKeyFactory.js
@@ -20,7 +20,7 @@ export const userKeys = {
   all: ['users'],
   lists: () => [...userKeys.all, 'list'],
   details: () => [...userKeys.all, 'detail'],
-  detail: (userId) => [...userKeys.all, 'detail', userId],
+  detail: (userId) => [...userKeys.details(), userId],
   pages: () => [...userKeys.all, 'page'],
   page: (page) => [...userKeys.pages(), page],
 };

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { Form } from 'react-bootstrap';
@@ -16,6 +16,7 @@ import { MyPageContainer } from '../styles/LayoutStyles';
 import { NextButton } from '../styles/ButtonStyles';
 import LoadingSpinner from '../components/LoadingSpinner';
 import DeleteUserModal from '../components/modal/DeleteUserModal';
+import { getUserInfo } from '../store/Slices/auth';
 
 const usernameSchema = yup
   .object({
@@ -29,7 +30,7 @@ const usernameSchema = yup
 export default function MyPage() {
   const navigate = useNavigate();
   const [show, setShow] = useState(false);
-  // const [isChecked, setIsChecked] = useState(false);
+  const dispatch = useDispatch();
 
   const { user } = useSelector((state) => state.user);
 
@@ -58,6 +59,7 @@ export default function MyPage() {
     }
 
     await updateUser({ updatedInfo });
+    dispatch(getUserInfo());
     navigate('/');
   };
 


### PR DESCRIPTION
### 구현 기능
- 마이페이지에서 유저 정보 변경 후 업데이트 안되는 버그 해결
- queryKey detail 부분 수정

기존에 useAuth 커스텀 훅 사용시 유저 정보를 매번 가져왔기 때문에 마이페이지에서 유저 정보 변경 후 업데이트 하지 않아도 되었으나, 커스텀 훅 삭제 후 유저 정보 변경 후 업데이트 안되는 버그 발견 
-> 유저 정보 변경 시 user 정보 다시 가져오는 getUserInfo 로직 추가해서 유저 정보 업데이트 하여 해결