### PR TITLE
fix: 랜덤 질문 버그 해결

### DIFF
--- a/src/apis/questions.js
+++ b/src/apis/questions.js
@@ -1,11 +1,13 @@
 import { api } from './api';
 
+const questionsParams = {
+  params: {
+    take: 50,
+  },
+};
+
 export const getQuestions = async () => {
-  const response = await api.get('/questions', {
-    params: {
-      take: 50,
-    },
-  });
+  const response = await api.get('/questions', questionsParams);
 
   return response.data.body;
 };
@@ -16,7 +18,7 @@ export const getQuestionsByCategory = async (category) => {
   if (category.toLowerCase() !== 'all') {
     url += `?category=${category.toLowerCase()}`;
   }
-  const response = await api.get(url);
+  const response = await api.get(url, questionsParams);
 
   return response.data.body.data;
 };

--- a/src/components/question/RandomQuestion.jsx
+++ b/src/components/question/RandomQuestion.jsx
@@ -15,6 +15,7 @@ export default function RandomQuestion({
           다음 질문
         </HomeNextButton>
 
+        {/* TODO:styled-components 사용시 커스텀 안됨 */}
         <DropdownButton
           style={{
             color: GREYS.DARKEST,

--- a/src/hooks/queries/useGetQuestionsByCategory.js
+++ b/src/hooks/queries/useGetQuestionsByCategory.js
@@ -3,7 +3,7 @@ import { getQuestionsByCategory } from '../../apis/questions';
 import { questionKeys } from '../../constant/queryKeyFactory';
 
 export const useGetQuestionsByCategory = ({ category }) => {
-  const queryData = useQuery(questionKeys.categories(), () =>
+  const queryData = useQuery(questionKeys.category(category), () =>
     getQuestionsByCategory(category)
   );
 


### PR DESCRIPTION
### 구현 기능
- 쿼리파람스 변수로 빼서 데이터 요청시 인자로 넣어주도록 수정
- 쿼리 키 설정 시 카테고리 매개변수로 넣어줌

Home 화면에서 다음 질문 버튼 클릭 해다 카테고리에 맞춰 랜덤으로 질문이 보여져야 하는데 카테고리 설정이 안되고 전체 질문이 나오는 버그 발견 
->  쿼리 키 설정시 매개변수로 카테고리를 안 넘겨주고 있어서 문제 발생했고 매개변수 넣어줘서 해결