### PR TITLE
refactor/searchQuestion : 스로틀링을 이용한 이벤트, 함수 호출 최적화

### DIFF
--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -6,16 +6,24 @@ import SearchQuetions from './SearchQuetions';
 import { useNavigate } from 'react-router-dom';
 import { GREYS } from '../../styles/variables';
 import { useSearchQuestions } from '../../hooks/queries/useSearchQuestions';
+import useThrottle from '../../utils/throttle';
 import { OpacityDiv, SearchInput } from '../../styles/Styles';
 
 export default function SearchBar() {
   const navigate = useNavigate();
   const [show, setShow] = useState(false);
   const [searchInput, setSearchInput] = useState('');
+  const throttleSearch = useThrottle(searchInput, 500);
   const defferedSearchInput = useDeferredValue(searchInput);
   const isStale = searchInput !== defferedSearchInput;
 
-  const { data: searchResults } = useSearchQuestions({ searchInput });
+  const { data: searchResults } = useSearchQuestions({
+    searchInput: throttleSearch,
+  });
+
+  const onChangeSearchInput = (e) => {
+    setSearchInput(e.target.value);
+  };
 
   const handleClose = () => {
     setSearchInput('');
@@ -51,7 +59,7 @@ export default function SearchBar() {
             <SearchInput
               placeholder='Search Questions'
               value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
+              onChange={onChangeSearchInput}
               autoFocus
             />
           </label>

--- a/src/hooks/queries/useSearchQuestions.js
+++ b/src/hooks/queries/useSearchQuestions.js
@@ -3,9 +3,14 @@ import { getQuestionsByKeyword } from '../../apis/questions';
 import { questionKeys } from '../../constant/queryKeyFactory';
 
 export const useSearchQuestions = ({ searchInput: keyword }) => {
-  const queryKey =
-    keyword.length > 0 ? questionKeys.keyword(keyword) : questionKeys.all;
-  const queryData = useQuery(queryKey, () => getQuestionsByKeyword(keyword));
+  const queryData = useQuery(
+    questionKeys.keyword(keyword),
+    () => getQuestionsByKeyword(keyword),
+    {
+      enabled: !!keyword,
+      select: (questions) => questions.slice(0, 10),
+    }
+  );
 
   return queryData;
 };

--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export default function useThrottle(value, delay) {
+  const [throttledValue, setThrottledValue] = useState(value);
+  const [lastExecTime, setLastExecTime] = useState(0);
+
+  useEffect(() => {
+    const now = Date.now();
+
+    if (now - lastExecTime > delay) {
+      setThrottledValue(value);
+      setLastExecTime(now);
+    }
+  }, [value, delay, lastExecTime]);
+
+  return throttledValue;
+}


### PR DESCRIPTION
### 구현 기능
- 검색 기능 enabled 옵션 활용하여 검색어 입력 이후 쿼리 실행되도록 제어
- 검색어 추천 시 500ms 시간 동안 한 번만 이벤트 갱신되어 함수 호출하도록 최적화

### 해결하고자 한 문제

1. 기존에 검색 기능 사용하지 않아도 검색어 쿼리 실행 되었던 문제 발견 
-> enabled 활용하여 입력 이후에 쿼리 실행되도록 제어

2. 기존 검색어 추천 기능에서 모든 입력에 따라 이벤트가 발생하고 해당 이벤트에 따라 함수 요청이 들어가 너무 많은 호출 발생 문제 발견 
-> useThrottle 훅을 구현하여 입력 값의 변경부터 일정 시간(500ms)동안 값이 한 번만 갱신되도록 하여 함수 호출 최적화