### PR TITLE
refactor/socialLogin: 기존의 auth 커스텀 훅 걷어내고 소셜 로그인 로직 리팩토링

### DIFF
--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -1,4 +1,4 @@
-import { api } from './api';
+import { api, authApi } from './api';
 
 // 회원가입
 export const signUpHandler = async (userInput) => {
@@ -46,5 +46,15 @@ export const checkVerificationCode = async (data) => {
     return true;
   } else {
     return false;
+  }
+};
+
+// 소셜 회원가입: 추가 정보 요청(닉네임, 이용약관)
+export const socialSignUp = async (signUpInfo) => {
+  try {
+    const { status } = await authApi.patch('/auth/update', signUpInfo);
+    return status;
+  } catch (error) {
+    console.log('소셜 로그인(회원가입) 에러 발생');
   }
 };

--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -26,4 +26,4 @@ export const updateUserInfoByUser = async ({ updatedInfo }) => {
   return data.body;
 };
 
-// 유저 정보 삭제
+// TODO: 유저 정보 삭제 API가 아직 안나옴

--- a/src/components/SocialSignUp.jsx
+++ b/src/components/SocialSignUp.jsx
@@ -2,11 +2,10 @@ import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Form } from 'react-bootstrap';
 import { Controller, useForm } from 'react-hook-form';
-import { serverApi } from '../apis/api';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { TERMS_AND_CONDITIONS } from '../constant/signUp';
-import { useSignUpHandler } from '../hooks/common/useSignUpHandler';
+import { useSocialSignUpHandler } from '../hooks/common/useSocialSignUpHandler';
 import { MESSAGE } from '../constant/message';
 import LoadingSpinner from './LoadingSpinner';
 import { ErrorMessage } from '../styles/Styles';
@@ -24,9 +23,9 @@ const signUpSchema = yup.object().shape({
 });
 
 export default function SocialSignUp() {
-  const [agreeList, setAgreeList] = useState(TERMS_AND_CONDITIONS);
   const navigate = useNavigate();
   const location = useLocation();
+  const [agreeList, setAgreeList] = useState(TERMS_AND_CONDITIONS);
 
   const {
     handleSubmit,
@@ -38,15 +37,11 @@ export default function SocialSignUp() {
     resolver: yupResolver(signUpSchema),
   });
 
-  const {
-    //TODO: 소셜 회원가입시 API 연결
-    // mutateAsync: signUp,
-    isLoading: loadingSignUp,
-    // error: errorSignUp,
-  } = useSignUpHandler();
+  //TODO: 소셜 회원가입시 API 연결
+  const { mutateAsync: socialSignUp, isLoading: loadingSocialSignUpUser } =
+    useSocialSignUpHandler();
 
-  const userInfo = location.state.userInfo?.userInfo;
-  const accessToken = location.state.token;
+  const userInfo = location.state.userInfo;
 
   const handleAgreeCheckList = (e, field, setFieldValue) => {
     const { value, checked } = e.target;
@@ -78,9 +73,6 @@ export default function SocialSignUp() {
     const allTrue = values.allTrue;
     const signUpInfo = {
       username: values.username,
-      // email: userInfo?.email,
-      // profileImg: userInfo.picture || '',
-      // provider: 'google',
 
       fourteenOverAgree: allTrue || !!values.fourteenOverAgree,
       termsOfUseAgree: allTrue || !!values.termsOfUseAgree,
@@ -89,25 +81,8 @@ export default function SocialSignUp() {
       smsAndEventAgree: allTrue || !!values.smsAndEventAgree,
     };
 
-    // TODO: 회원가입시 비밀번호 없는 상태로 요청
-    const config = {
-      headers: {
-        Authorization: 'Bearer ' + accessToken,
-      },
-    };
-
-    try {
-      const { status } = await serverApi.patch(
-        '/auth/update',
-        signUpInfo,
-        config
-      );
-      if (status === 200) {
-        navigate('/');
-      }
-    } catch (error) {
-      console.log('소셜 로그인(회원가입) 에러 발생');
-    }
+    await socialSignUp(signUpInfo);
+    navigate('/');
   };
 
   return (
@@ -183,7 +158,7 @@ export default function SocialSignUp() {
         </Form.Group>
 
         <NextButton variant='Light' type='submit' className='w-100 mt-3'>
-          {loadingSignUp ? <LoadingSpinner /> : '회원가입'}
+          {loadingSocialSignUpUser ? <LoadingSpinner /> : '회원가입'}
         </NextButton>
       </Form>
     </SocialContainer>

--- a/src/hooks/common/useSocialSignUpHandler.js
+++ b/src/hooks/common/useSocialSignUpHandler.js
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { socialSignUp } from '../../apis/auth';
+import { userKeys } from '../../constant/queryKeyFactory';
+
+export const useSocialSignUpHandler = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (updatedInfo) => socialSignUp(updatedInfo),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: userKeys.detail(data.id),
+      });
+    },
+    onError: (error) => {
+      console.log('Social SignUp Error', error.message);
+      alert('오류가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+      throw new Error();
+    },
+  });
+};


### PR DESCRIPTION
### 구현 기능
- 기존의 useAuth 커스텀 훅으로 관리하던 유저정보 걷어내고 redux store에서 유저 정보 가져와서 소셜 로그인 로직 리팩토링

소셜 회원가입 시 사용자 추가 정보(닉네임, 이용약관) 입력 받고 있음